### PR TITLE
Fix mongo-server to version 4.4.8

### DIFF
--- a/express-mongo-docker/docker-compose.yaml
+++ b/express-mongo-docker/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.8'
 services:
   database:
     container_name: mongo-server
-    image: mongo
+    image: mongo:4.4.8
     restart: always
     environment: 
       - MONGO_INITDB_ROOT_USERNAME=admin


### PR DESCRIPTION
Accordingly to [Mongo Production Notes](https://docs.mongodb.com/manual/administration/production-notes/#supported-platforms) mongo 5.0 release requires specific processors architectures to work in different platforms

Olá Luis, estava testando seu codigo na minha maquina mas como meu processador é antigo o compose não funcionou. Investigando o problema descobri que o compose estava baixando a versão mais recente do mongo para instanciar o mongo-server e isso é ou pode ser um problema para pessoas que não possuam maquinas com processador tão recente. Para manter o o projeto atualizado de forma que todospossam aproveitar o conteudo eu resolvi compartilhar uma correção simples.